### PR TITLE
empty object also has property in prototype

### DIFF
--- a/MingGe_1.6.js
+++ b/MingGe_1.6.js
@@ -1182,7 +1182,9 @@
         },
         isEmptyObject: function(obj) {
             for (var name in obj) {
-                return false;
+                if(obj.hasOwnProperty(name)) {
+                    return false;
+                }
             }
             return true;
         },


### PR DESCRIPTION
空对象判断时，原型链上的属性不应该影响判断结果。